### PR TITLE
[FE] feat:  모든 페이지에 배경음 자동재생 적용 (muted → unmute 방식으로 브라우저 제한 우회)

### DIFF
--- a/main/templates/main/custom_questions.html
+++ b/main/templates/main/custom_questions.html
@@ -75,5 +75,6 @@
     </form>
 
     <script src="{% static 'js/custom.js' %}"></script>
+    <script src="{% static 'js/start.js' %}"></script>
   </body>
 </html>

--- a/main/templates/main/game.html
+++ b/main/templates/main/game.html
@@ -182,5 +182,6 @@
     </div>
 
     <script src="{% static 'js/game.js' %}"></script>
+    <script src="{% static 'js/start.js' %}"></script>
   </body>
 </html>

--- a/main/templates/main/result.html
+++ b/main/templates/main/result.html
@@ -126,5 +126,6 @@
         </div>
       </div>
     </div>
+    <script src="{% static 'js/start.js' %}"></script>
   </body>
 </html>

--- a/main/templates/main/setup.html
+++ b/main/templates/main/setup.html
@@ -208,5 +208,6 @@
         </div>
       </form>
     </div>
+    <script src="{% static 'js/start.js' %}"></script>
   </body>
 </html>

--- a/marblekiri/static/js/start.js
+++ b/marblekiri/static/js/start.js
@@ -1,22 +1,24 @@
 document.addEventListener("DOMContentLoaded", () => {
-  // 배경 음악 설정
+  // 1. 오디오 객체 생성
   const bgMusic = new Audio("/static/assets/sounds/gamebackground.mp3");
-  bgMusic.loop = true;          // 반복 재생 설정
-  bgMusic.volume = 0.5;         // 볼륨 설정 (0.0 ~ 1.0)
 
-  // '시작하기' 버튼 클릭 시 배경 음악 정지 및 초기화
-  const startButton = document.querySelector(".start_button");
-  startButton.addEventListener("click", () => {
-    bgMusic.pause();
-    bgMusic.currentTime = 0;
-  });
+  // 2. 자동 재생을 위한 조건: muted 먼저 설정!
+  bgMusic.loop = true;
+  bgMusic.volume = 0.5;
+  bgMusic.muted = true;
 
-  // 사용자 최초 클릭 시 배경 음악 재생 (브라우저 자동 재생 제한 대응)
-  document.body.addEventListener("click", () => {
-    if (bgMusic.paused) {
-      bgMusic.play()
-        .then(() => console.log("배경음 재생 시작"))
-        .catch((e) => console.warn("배경음 재생 실패:", e));
-    }
-  }, { once: true }); // 최초 클릭 한 번만 적용
+  // 3. muted 상태로 재생 시도
+  bgMusic.play()
+    .then(() => {
+      console.log("✅ 자동재생 성공 (muted 상태)");
+
+      // 4. 소리 켜기 (지연 후 우회)
+      setTimeout(() => {
+        bgMusic.muted = false;
+        console.log("🔊 소리 켜짐");
+      }, 500); // 1초 후 unmute
+    })
+    .catch((e) => {
+      console.warn("❌ 자동재생 실패:", e);
+    });
 });


### PR DESCRIPTION
🔥 Pull requests
👷 작업한 내용
- Audio 객체를 muted 상태로 자동재생하여 브라우저 autoplay 제한 우회
- 일정 시간 후 muted 해제하여 사용자에게 배경음이 들리도록 처리
- 모든 페이지 공통으로 배경음 재생되도록 공통 JS 또는 레이아웃에 삽입
